### PR TITLE
add category in transaction object

### DIFF
--- a/back_end/controllers/transaction.js
+++ b/back_end/controllers/transaction.js
@@ -1,4 +1,5 @@
 import { Transaction } from '../models/Transaction.js';
+import { Category } from '../models/Category.js';
 import { Op } from 'sequelize';
 import { calculateBalances } from '../helper/balance.js';
 
@@ -8,9 +9,10 @@ const listTransactions = async (req, res) => {
     let allTransactions = [];
 
     if (startedDate === undefined && endedDate === undefined) {
-      allTransactions = await Transaction.findAll();
+      allTransactions = await Transaction.findAll({ include: Category });
     } else {
       allTransactions = await Transaction.findAll({
+        include: Category,
         where: {
           date: {
             [Op.between]: [startedDate, endedDate],
@@ -31,6 +33,7 @@ const getTransaction = async (req, res) => {
   const { id } = req.params;
   try {
     const transaction = await Transaction.findOne({
+      include: Category,
       where: {
         id: id,
       },


### PR DESCRIPTION
You can delete a category that is associated to a transaction. 
If you do so, the transaction is going to have category_id null. Example:
```
    {
        "id": "3214e67d-4de3-412f-87a9-2ed4c3ebd0dd",
        "description": "Freelance services",
        "type": "income",
        "amount": "1800.00",
        **"category_id": null,
        "category": null,**
        "balance": 7680
        ......
    },
```

If the transaction has a category associated to it. The object is going to look like this:
```
    {
        "id": "185c020f-6972-4cc9-a2a2-b94c96b3a616",
        "description": "Tram ticket",
        "type": "expense",
        "amount": "120.00",
        "category_id": "1c97e892-2616-488c-b5c0-9c4e107115c6",
        "category": {
            "id": "1c97e892-2616-488c-b5c0-9c4e107115c6",
            "name": "Car",
            "description": "Transportation",
            "icon": "ElectricCarIcon",
            "color": "#9f40bf",
           .....
        },
        "balance": 5880
        ....
    }
```